### PR TITLE
Implement echo response without decryption 

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ cmake --build build/
 - [x] Requires user authentication before echoing
 - [x] Accepts any combination of username and password
 - [x] Keeps a per-session user context, containing the username and password checksums
+- [x] Echoes the message from the request
 - [ ] Decrypts client messages
-- [ ] Echoes the plain (decrypted) message from the echo request
 
 ## Reference client implementation:
 

--- a/include/mori_echo/server_config.hpp
+++ b/include/mori_echo/server_config.hpp
@@ -13,4 +13,6 @@ inline constexpr auto byte_order = endian_mode::LITTLE_ENDIAN_MODE;
 inline constexpr auto username_size = std::size_t{32};
 inline constexpr auto password_size = std::size_t{32};
 
+inline constexpr auto enable_decryption = false;
+
 } // namespace mori_echo::config

--- a/server/include/exceptions/server_error.hpp
+++ b/server/include/exceptions/server_error.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <stdexcept>
+
+namespace mori_echo::exceptions {
+
+class server_error : public std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
+
+} // namespace mori_echo::exceptions

--- a/server/include/message_sender/message_sender.hpp
+++ b/server/include/message_sender/message_sender.hpp
@@ -3,6 +3,7 @@
 #include <boost/asio/awaitable.hpp>
 
 #include "client_channel/client_channel.hpp"
+#include "message_types/echo_response.hpp"
 #include "message_types/login_response.hpp"
 #include "message_types/message_base.hpp"
 #include "mori_status/login_status.hpp"
@@ -14,6 +15,12 @@ template <messages::MoriEchoMessage T> struct send_message;
 template <> struct send_message<messages::login_response> {
   auto operator()(client_channel& channel, std::uint8_t sequence,
                   mori_status::login_status status_code)
+      -> boost::asio::awaitable<void>;
+};
+
+template <> struct send_message<messages::echo_response> {
+  auto operator()(client_channel& channel, std::uint8_t sequence,
+                  const std::vector<std::byte>& message)
       -> boost::asio::awaitable<void>;
 };
 

--- a/server/src/echo_server/echo_server.cpp
+++ b/server/src/echo_server/echo_server.cpp
@@ -15,8 +15,11 @@
 #include "exceptions/client_error.hpp"
 #include "message_receiver/message_receiver.hpp"
 #include "message_sender/message_sender.hpp"
+#include "message_types/echo_request.hpp"
+#include "message_types/echo_response.hpp"
 #include "message_types/login_request.hpp"
 #include "message_types/login_response.hpp"
+#include "mori_echo/server_config.hpp"
 #include "mori_status/login_status.hpp"
 
 namespace mori_echo {
@@ -50,6 +53,14 @@ auto log_client_error(const std::exception& error,
 
   switch (header.type) {
     case messages::message_type::ECHO_REQUEST: {
+      const auto echo = co_await receive_message<messages::echo_request>(
+          channel, std::move(header));
+
+      if constexpr (config::enable_decryption) {
+      } else {
+        co_await send_message<messages::echo_response>{}(
+            channel, echo.header.sequence, echo.cipher_message);
+      }
     } break;
 
     case messages::message_type::LOGIN_RESPONSE:

--- a/server/src/message_sender/message_sender.cpp
+++ b/server/src/message_sender/message_sender.cpp
@@ -3,6 +3,8 @@
 #include <boost/endian/conversion.hpp>
 #include <cstdint>
 
+#include "exceptions/server_error.hpp"
+#include "message_types/echo_response.hpp"
 #include "message_types/login_response.hpp"
 #include "mori_echo/server_config.hpp"
 #include "mori_status/login_status.hpp"
@@ -52,6 +54,41 @@ auto send_message<messages::login_response>::operator()(
   }
 
   co_await channel.send_as(login_status_code);
+}
+
+auto send_message<messages::echo_response>::operator()(
+    client_channel& channel, std::uint8_t sequence,
+    const std::vector<std::byte>& message) -> boost::asio::awaitable<void> {
+  constexpr auto max_message_size = std::numeric_limits<std::uint16_t>::max() -
+                                    sizeof(std::uint16_t) - header_size;
+
+  if (message.size() > max_message_size) {
+    throw exceptions::server_error{"Message too long."};
+  }
+
+  auto total_size = static_cast<std::uint16_t>(
+      header_size + sizeof(std::uint16_t) + message.size());
+
+  if constexpr (config::byte_order == config::endian_mode::LITTLE_ENDIAN_MODE) {
+    boost::endian::native_to_little_inplace(total_size);
+  } else {
+    boost::endian::native_to_big_inplace(total_size);
+  }
+
+  co_await send_header(channel, total_size,
+                       messages::message_type::ECHO_RESPONSE, sequence);
+
+  auto message_size = static_cast<std::uint16_t>(message.size());
+
+  if constexpr (config::byte_order == config::endian_mode::LITTLE_ENDIAN_MODE) {
+    boost::endian::native_to_little_inplace(message_size);
+  } else {
+    boost::endian::native_to_big_inplace(message_size);
+  }
+
+  co_await channel.send_as(message_size);
+
+  co_await channel.send(message);
 }
 
 } // namespace mori_echo


### PR DESCRIPTION
This PR adds initial support for echo response, without decryption, which is the next step.

The `message_sender` was refactored to improve the developer experience on serialization routines, making the necessary arguments explicit in the header and allowing implicit conversions (e.g. const references).

A new static configuration was added: `enable_decryption`. This flag controls whether the server will decrypt client messages or not, before sending an echo response.